### PR TITLE
simplejson 3.17.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.17.3" %}
+{% set version = "3.17.6" %}
 
 package:
   name: simplejson
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/simplejson/simplejson-{{ version }}.tar.gz
-  sha256: da72a452bcf4349fc467a12b54ab0e63e654a571cacc44084826d52bde12b6ee
+  sha256: cf98038d2abf63a1ada5730e91e84c642ba6c225b0198c3684151b1f80c5f8a6
 
 build:
-  number: 2
+  number: 0
   script:
     - export REQUIRE_SPEEDUPS=1  # [not win]
     - set REQUIRE_SPEEDUPS=1  # [win]


### PR DESCRIPTION
Version change: bump version number from 3.17.3 to 3.17.6
Requirements from conda-forge: https://github.com/conda-forge/simplejson-feedstock/blob/master/recipe/meta.yaml
Bug Tracker: new open issues https://github.com/simplejson/simplejson/issues
Github releases:  https://github.com/simplejson/simplejson/releases
Upstream Changelog: https://github.com/simplejson/simplejson/blob/master/CHANGES.txt
Upstream setup.py:  https://github.com/simplejson/simplejson/blob/v3.17.6/setup.py

The package simplejson is mentioned inside the packages:
arrow | cherrypy | marshmallow | python-nvd3 | tabpy-server |

Actions:
1. Reset build number to `0`

Result:
- all-succeeded