### PR TITLE
Update 3.19.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.17.6" %}
+{% set version = "3.19.2" %}
 
 package:
   name: simplejson
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/simplejson/simplejson-{{ version }}.tar.gz
-  sha256: cf98038d2abf63a1ada5730e91e84c642ba6c225b0198c3684151b1f80c5f8a6
+  sha256: 9eb442a2442ce417801c912df68e1f6ccfcd41577ae7274953ab3ad24ef7d82c
 
 build:
   number: 0
@@ -33,7 +33,7 @@ test:
     - simplejson._speedups   # [python_impl != 'pypy']
     - simplejson.tests
   requires:
-    - pip 
+    - pip
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
     JSON <https://json.org> encoder and decoder for Python 2.5+ and
     Python 3.3+. It is pure Python code with no dependencies, but includes
     an optional C extension for a serious speed boost.
-  doc_url: https://readthedocs.org/projects/simplejson/
+  doc_url: https://simplejson.readthedocs.io/
   dev_url: https://github.com/simplejson/simplejson
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
     - export REQUIRE_SPEEDUPS=1  # [not win]
     - set REQUIRE_SPEEDUPS=1  # [win]
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True # [py<38]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ build:
   script:
     - export REQUIRE_SPEEDUPS=1  # [not win]
     - set REQUIRE_SPEEDUPS=1  # [win]
-    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True # [py<38]
 
 requirements:
   build:
@@ -43,13 +44,12 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: Simple, fast, extensible JSON encoder/decoder for Python
-
   description: |
     simplejson is a simple, fast, complete, correct and extensible
     JSON <https://json.org> encoder and decoder for Python 2.5+ and
     Python 3.3+. It is pure Python code with no dependencies, but includes
     an optional C extension for a serious speed boost.
-  doc_url: https://simplejson.readthedocs.io/
+  doc_url: https://readthedocs.org/projects/simplejson/
   dev_url: https://github.com/simplejson/simplejson
 
 extra:


### PR DESCRIPTION
## ☆Simplejson 3.19.2 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5249)
[Upstream](https://github.com/simplejson/simplejson)
# Changes
- Updated version number and `sha256`
- Skip to `python` versions less than 3.8